### PR TITLE
envio de email para troca de senha #12

### DIFF
--- a/src/main/java/com/grupo04/Biblioteca/Service/EnviarEmail.java
+++ b/src/main/java/com/grupo04/Biblioteca/Service/EnviarEmail.java
@@ -1,5 +1,25 @@
-public void enviarAvisoTrocaSenha(String email) {
-    // você pode reaproveitar seu método de envio aqui dentro
-    enviarEmail(email, "Aviso de Segurança", 
-        "Olá! Por segurança, recomendamos que você altere sua senha.");
+package com.grupo04.Biblioteca.services;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EnviarAviso {
+
+    @Async
+    public void enviarAvisoTrocaSenha(String dsEmail, String nmBibliotecario) {
+        try {
+            Thread.sleep(3000);
+
+            System.out.println("=================================");
+            System.out.println("AVISO DE TROCA DE SENHA");
+            System.out.println("E-mail enviado para: " + dsEmail);
+            System.out.println("Bibliotecário: " + nmBibliotecario);
+            System.out.println("Mensagem: Olá, por segurança, recomendamos que você altere sua senha.");
+            System.out.println("=================================");
+
+        } catch (InterruptedException e) {
+            System.out.println("Erro ao enviar o aviso de troca de senha");
+        }
+    }
 }

--- a/src/main/java/com/grupo04/Biblioteca/Service/EnviarEmail.java
+++ b/src/main/java/com/grupo04/Biblioteca/Service/EnviarEmail.java
@@ -1,0 +1,5 @@
+public void enviarAvisoTrocaSenha(String email) {
+    // você pode reaproveitar seu método de envio aqui dentro
+    enviarEmail(email, "Aviso de Segurança", 
+        "Olá! Por segurança, recomendamos que você altere sua senha.");
+}

--- a/src/main/java/com/grupo04/Biblioteca/controllers/BibliotecarioController.java
+++ b/src/main/java/com/grupo04/Biblioteca/controllers/BibliotecarioController.java
@@ -127,4 +127,17 @@ public class BibliotecarioController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
         }
     }
+
+    @GetMapping("/enviar-aviso-senha")
+    public ResponseEntity<String> enviarAvisoSenha() {
+
+        List<BibliotecarioModel> lista = repository.findAll();
+
+        for (BibliotecarioModel b : lista) {
+            enviarEmail.enviarAvisoTrocaSenha(b.getEmail());
+        }
+
+        return ResponseEntity.ok("Emails enviados!");
+    }
+
 }


### PR DESCRIPTION
#unilopers12

Implementação do envio de aviso de troca de senha para bibliotecários.

- Criação do service EnviarAviso
- Integração com controller para envio dos avisos